### PR TITLE
Allow partial syncs

### DIFF
--- a/cfg/filter.go
+++ b/cfg/filter.go
@@ -1,0 +1,30 @@
+package cfg;
+
+func FilterCharts(config Config, charts []string) Config {
+	chartsToFilter := make(map[string]bool)
+	reposToFilter := make(map[string]bool)
+
+	for _, name := range charts {
+		chartsToFilter[name] = true
+	}
+
+	var filteredCharts []map[string]string
+	for _, chart := range config.Charts {
+		if chartsToFilter[chart["name"]] {
+			filteredCharts = append(filteredCharts, chart)
+			reposToFilter[chart["repo_name"]] = true
+		}
+	}
+
+	var filteredRepos []map[string]string
+	for _, repo := range config.Repos {
+		if reposToFilter[repo["name"]] {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+
+	config.Charts = filteredCharts
+	config.Repos = filteredRepos
+
+	return config
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -23,6 +23,11 @@ Running a git diff then will help to see any differences`,
 			os.Exit(1)
 		}
 
+		onlyCharts, _ := cmd.Flags().GetStringSlice("only-charts")
+		if len(onlyCharts) > 0 {
+			config = cfg.FilterCharts(config, onlyCharts)
+		}
+
 		err = exec.AddAllRepos(config)
 		if err != nil {
 			fmt.Printf("Error message: %s", err)
@@ -53,4 +58,5 @@ func init() {
 	rootCmd.AddCommand(syncCmd)
 
 	syncCmd.Flags().StringP("config-file", "f", "./helm-freeze.yaml", "Configuration file")
+	syncCmd.Flags().StringSlice("only-charts", []string{}, "Sync only these charts")
 }


### PR DESCRIPTION
Fixes #3

This PR adds a new flag named `--only-charts` to the `sync` command. It allows to filter the charts to sync. This is quite helpful in case you have a lot charts in your `helm-freeze.yaml`.

* `helm-freeze sync` syncs all charts
* `helm-freeze sync --only-charts abc` syncs only the chart named `abc`
* `helm-freeze sync --only-charts abc,def,ghi` syncs only the charts named `abc`, `def` and `ghi`

When you pass a chart name to `--only-charts` that does not exist, it will be ignored.